### PR TITLE
Added ARM32 and ARM64 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ mkdir llvm
 ```
 
 Where the first argument is an empty directory for building LLVM.
-The location of this LLVM installation will be `./llvm/install`
+The location of this LLVM installation will be `./llvm/install`.
+
+If you are building for an architecture other than `x86` (e.g. `AArch64`), set the variable `LLVM_TARGETS_TO_BUILD` to your preferred architecture.
+
+If you could like to be able compile using additional tools (e.g. OpenMP), add them to the variable `LLVM_ENABLE_PROJECTS`, separated by `;` (e.g. `-DLLVM_ENABLE_PROJECTS="clang;openmp"`).
 
 #### Option 2 — Polly Knobs *(depreciated)*
 
@@ -64,6 +68,8 @@ Ubuntu amounts to running:
 ```bash
 sudo apt install libdispatch0 libdispatch-dev
 ```
+
+It is also quick to build yourself.
 
 ### Step 3
 

--- a/runtime/InitNativeTarget.cpp
+++ b/runtime/InitNativeTarget.cpp
@@ -10,10 +10,24 @@ namespace {
 class InitNativeTarget {
   public:
   InitNativeTarget() {
+#if defined(__i386__) || defined(__amd64__)
     LLVMInitializeX86Target();
     LLVMInitializeX86TargetInfo();
     LLVMInitializeX86TargetMC();
     LLVMInitializeX86AsmPrinter();
+#elif defined(__arm__)
+    LLVMInitializeARMTarget();
+    LLVMInitializeARMTargetInfo();
+    LLVMInitializeARMTargetMC();
+    LLVMInitializeARMAsmPrinter();
+#elif defined(__aarch64__)
+    LLVMInitializeAArch64Target();
+    LLVMInitializeAArch64TargetInfo();
+    LLVMInitializeAArch64TargetMC();
+    LLVMInitializeAArch64AsmPrinter();
+#else
+#error ARCH not supported
+#endif
     sys::DynamicLibrary::LoadLibraryPermanently(nullptr);
   }
 } Init;


### PR DESCRIPTION
This amounts to accessing the relevant LLVM functions for the target architecture.

Currently chosen at compile time by compiler macros.

Could be improved by this being set by a build flag.

Have not added to CI for testing, but have tested on a machine of my own.  Note that the Debian packages for libdispatch for AArch64 do not seem to work, and thus the library needs to be compiled manually.